### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/src/apiProxy.ts
+++ b/src/apiProxy.ts
@@ -57,7 +57,7 @@ export async function getOboToken(userAccessToken: string, scope: string) {
     console.log("Requested new access token");
     return onBehalfOfResponse.data;
   } catch (error) {
-    console.log("error", error);
-    return error
+    console.error("Error occurred while requesting new access token:", error);
+    return { error: "An error occurred while processing your request. Please try again later." };
   }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,8 +7,12 @@ const routes = Router();
 export const helloWorldRoute = routes.get('/obo/:app',
     verifyJWTToken,
     async (req, res) => {
-        const token = await getOboToken(getTokenFromRequestHeader(req), req.params.app);
-        res.send(token);
+        const tokenResponse = await getOboToken(getTokenFromRequestHeader(req), req.params.app);
+        if (tokenResponse.error) {
+            res.status(500).send(tokenResponse.error);
+        } else {
+            res.send(tokenResponse);
+        }
 });
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/org-token-tool/security/code-scanning/5](https://github.com/navikt/org-token-tool/security/code-scanning/5)

To fix the problem, we need to ensure that stack traces and sensitive error information are not exposed to the user. Instead, we should log the error on the server and send a generic error message to the user. This can be achieved by modifying the error handling in `src/apiProxy.ts` to log the error and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
