### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -11,7 +11,8 @@ export const helloWorldRoute = routes.get('/obo/:app',
             const tokenResponse = await getOboToken(getTokenFromRequestHeader(req), req.params.app);
             res.send(tokenResponse);
         } catch (error) {
-            res.status(500).send(error);
+            console.error("Error occurred:", error.stack || error); // Log the error details on the server
+            res.status(500).send("An internal server error occurred."); // Send a generic error message to the client
         }
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/org-token-tool/security/code-scanning/7](https://github.com/navikt/org-token-tool/security/code-scanning/7)

To fix the issue, the code should be modified to ensure that the `error` object is not sent directly to the client. Instead, a generic error message should be sent to the client, and the detailed error information (including the stack trace) should be logged on the server. This approach prevents sensitive information from being exposed while still allowing developers to debug issues using server-side logs.

The fix involves:
1. Replacing `res.status(500).send(error)` with a generic error message like `res.status(500).send("An internal server error occurred.")`.
2. Logging the detailed error information (e.g., `error.stack`) on the server using a logging mechanism.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
